### PR TITLE
Possible fix of start events concurrency issue

### DIFF
--- a/docker_enforcer.py
+++ b/docker_enforcer.py
@@ -53,6 +53,7 @@ def create_app():
     if config.run_periodic:
         periodic = Observable.interval(config.interval_sec * 1000) \
             .start_with(-1) \
+            .observe_on(scheduler=NewThreadScheduler()) \
             .map(lambda _: docker_helper.check_containers()) \
             .flat_map(lambda c: c)
 


### PR DESCRIPTION
Hi Lukasz,

As we discussed it this week. It is possible fix of issue when ever container check from periodic queue wait next start event.