### PR TITLE
Fix bug when DE recognize /networks/create API request as related to the container

### DIFF
--- a/docker_enforcer.py
+++ b/docker_enforcer.py
@@ -28,7 +28,7 @@ judge = Judge(rules, "container", config)
 requests_judge = Judge(request_rules, "request", config, run_whitelists=False)
 jurek = Killer(docker_helper, config.mode)
 trigger_handler = TriggerHandler()
-
+containers_regex = re.compile("^(/v.+?)?/containers/.+?$")
 
 def create_app():
     def setup_logging():
@@ -195,7 +195,6 @@ def authz_request():
     if verdict.verdict:
         return process_positive_verdict(verdict, json_data, register=False)
 
-    containers_regex = re.compile("^(/v.+?)?/containers/.+?$")
     operation = url.path.split("/")[-1]
     if containers_regex.match(url.path) and operation == "create" and "RequestBody" in json_data:
         int_bytes = b64decode(json_data["RequestBody"])

--- a/docker_enforcer.py
+++ b/docker_enforcer.py
@@ -30,6 +30,7 @@ jurek = Killer(docker_helper, config.mode)
 trigger_handler = TriggerHandler()
 containers_regex = re.compile("^(/v.+?)?/containers/.+?$")
 
+
 def create_app():
     def setup_logging():
         handler = StreamHandler(stream=sys.stdout)

--- a/docker_enforcer.py
+++ b/docker_enforcer.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import logging
+import re
 import signal
 import sys
 from base64 import b64decode
@@ -193,8 +194,10 @@ def authz_request():
     verdict = requests_judge.should_be_killed(json_data)
     if verdict.verdict:
         return process_positive_verdict(verdict, json_data, register=False)
+
+    containers_regex = re.compile("^(/v.+?)?/containers/.+?$")
     operation = url.path.split("/")[-1]
-    if operation == "create" and "RequestBody" in json_data:
+    if containers_regex.match(url.path) and operation == "create" and "RequestBody" in json_data:
         int_bytes = b64decode(json_data["RequestBody"])
         int_json = json.loads(int_bytes.decode(request.charset))
         container = make_container_periodic_check_compatible(int_json, url)


### PR DESCRIPTION
Following errir is throwed

2017-09-28 13:06:08,789 - docker_enforcer - ERROR - Exception on /AuthZPlugin.AuthZReq [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.5/dist-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.5/dist-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/vagrant/docker_enforcer/repo/docker-enforcer/docker_enforcer.py", line 203, in authz_request
    return process_positive_verdict(verdict, json_data)
  File "/vagrant/docker_enforcer/repo/docker-enforcer/docker_enforcer.py", line 237, in process_positive_verdict
    jurek.register_kill(verdict)
  File "/vagrant/docker_enforcer/repo/docker-enforcer/dockerenforcer/killer.py", line 204, in register_kill
    self._status.register_killed(verdict.subject, verdict.reasons)
  File "/vagrant/docker_enforcer/repo/docker-enforcer/dockerenforcer/killer.py", line 51, in register_killed
    else container.params["Image"]
KeyError: 'Image'