### PR TITLE
Fix/display name correctly in warning output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .idea/
 .coverage
+*.pyc

--- a/dockerenforcer/docker_helper.py
+++ b/dockerenforcer/docker_helper.py
@@ -34,7 +34,7 @@ class Container:
         self.owner: str = owner
 
     def __str__(self, *args, **kwargs) -> str:
-        return self.params.get('Name', self.cid)
+        return self.params.get('name', self.cid)
 
 
 class DockerHelper:

--- a/test/test_docker_helpers.py
+++ b/test/test_docker_helpers.py
@@ -14,7 +14,7 @@ class ContainerTests(unittest.TestCase):
         self.assertEqual("123", str(container))
 
     def test_create_with_name(self):
-        container = Container("123", {"Name": "container1"}, {"cpu": 7}, 0, CheckSource.Periodic)
+        container = Container("123", {"name": "container1"}, {"cpu": 7}, 0, CheckSource.Periodic)
         self.assertEqual("container1", str(container))
 
 


### PR DESCRIPTION
The Container ID was not very helpful when letting the container run in warning mode