### PR TITLE
Show a correct human readable image name in the violations list

### DIFF
--- a/dockerenforcer/killer.py
+++ b/dockerenforcer/killer.py
@@ -69,7 +69,7 @@ class StatusDictionary:
         with self._padlock:
             name = subject.params["name"]
             image = subject.params["config"]["image"] \
-                if "Config" in subject.params and "image" in subject.params["config"] \
+                if "config" in subject.params and "image" in subject.params["config"] \
                 else subject.params["image"]
             labels = subject.params["config"]["labels"] if "config" in subject.params \
                 else subject.params["labels"]

--- a/dockerenforcer/killer.py
+++ b/dockerenforcer/killer.py
@@ -70,7 +70,7 @@ class StatusDictionary:
             name = subject.params["name"]
             image = subject.params["config"]["image"] \
                 if "config" in subject.params and "image" in subject.params["config"] \
-                else subject.params["image"]
+                else (subject.params['image'] if 'image' in subject.params else 'UNDEFINED')
             labels = subject.params["config"]["labels"] if "config" in subject.params \
                 else subject.params["labels"]
             self._killed_containers.setdefault(subject.cid, Stat(name))\
@@ -144,7 +144,7 @@ class Judge:
 
     def _get_image_info(self, container: Container) -> str:
         image: str = container.params['config']['image'] if 'image' in container.params['config'] \
-            else container.params['image']
+            else (container.params['image'] if 'image' in container.params else 'UNDEFINED')
 
         if image.startswith("sha256:"):
             image = self._docker_image_helper.get_image_uniq_tag_by_id(image)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -7,10 +7,10 @@ from dockerenforcer.killer import Judge
 
 class RulesTestHelper:
     def __init__(self, rules, config=Config(), container_count=1, mem_limit=0, cpu_share=0, cpu_period=0, cpu_quota=0,
-                 mem_usage=0):
+                 mem_usage=0, container_params={}):
         self.judge = Judge(rules, "container", config)
         cid = '7de82a4e90f1bd4fd022bcce298e7277b8aec009e222892e44769d6c636b8205'
-        params = {'Image': 'sha256:47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb',
+        params = container_params if container_params else {'Image': 'sha256:47bcc53f74dc94b1920f0b34f6036096526296767650f223433fe65c35f149eb',
                   'HostConfig': {'Isolation': '', 'IOMaximumBandwidth': 0, 'CpuPercent': 0, 'ReadonlyRootfs': False,
                                  'CpuQuota': cpu_quota, 'IpcMode': '', 'RestartPolicy': {'Name': 'no', 'MaximumRetryCount': 0},
                                  'BlkioDeviceWriteIOps': None, 'PidMode': '', 'BlkioDeviceWriteBps': None,

--- a/test/test_killer.py
+++ b/test/test_killer.py
@@ -1,5 +1,6 @@
 import unittest
 from dockerenforcer.config import Config
+from dockerenforcer.killer import StatusDictionary
 from .test_helpers import RulesTestHelper
 
 
@@ -37,6 +38,18 @@ class ParamsRulesTests(TestsWithVerdicts):
                   and c.params['hostconfig']['cpuperiod'] == 0}]
         self.assertFalse(RulesTestHelper(rules, cpu_period=50000, cpu_quota=50000).get_verdicts()[0].verdict)
         self.assertTrue(RulesTestHelper(rules, cpu_period=0, cpu_quota=0).get_verdicts()[0].verdict)
+
+class StatusDictionaryTests(TestsWithVerdicts):
+    def test_correct_image(self):
+        rules = [{"name": "always True", "rule": lambda c: True}]
+        verdict_descr = RulesTestHelper(rules).get_verdicts()[0]
+        self.assertTrue(verdict_descr.verdict)
+
+        status = StatusDictionary()
+        status.register_killed(verdict_descr)
+
+        stat = list(status.get_items())[0]
+        self.assertEqual('busybox', stat[1].image)
 
 
 class MetricsRulesTests(TestsWithVerdicts):

--- a/test/test_killer.py
+++ b/test/test_killer.py
@@ -39,17 +39,68 @@ class ParamsRulesTests(TestsWithVerdicts):
         self.assertFalse(RulesTestHelper(rules, cpu_period=50000, cpu_quota=50000).get_verdicts()[0].verdict)
         self.assertTrue(RulesTestHelper(rules, cpu_period=0, cpu_quota=0).get_verdicts()[0].verdict)
 
-class StatusDictionaryTests(TestsWithVerdicts):
-    def test_correct_image(self):
+class CorrectImageNameTests(TestsWithVerdicts):
+    def test_correct_image_verdicts(self):
         rules = [{"name": "always True", "rule": lambda c: True}]
-        verdict_descr = RulesTestHelper(rules).get_verdicts()[0]
-        self.assertTrue(verdict_descr.verdict)
 
-        status = StatusDictionary()
-        status.register_killed(verdict_descr)
+        test_cases = [
+            {
+                "params": {"config": {"image": "busybox2", "labels": {}}, "image": "sha256:47bcffff", "name": "test1"},
+                "expected_image": "busybox2"
+            },
+            {
+                "params": {"config": {"labels": {}}, "name": "test2"},
+                "expected_image": "UNDEFINED"
+            }
+        ]
 
-        stat = list(status.get_items())[0]
-        self.assertEqual('busybox', stat[1].image)
+        for test in test_cases:
+            params = test["params"]
+
+            verdict_descr = RulesTestHelper(rules, container_params=params).get_verdicts()[0]
+            self.assertTrue(verdict_descr.verdict)
+
+            status = StatusDictionary()
+            status.register_killed(verdict_descr)
+
+            stat = list(status.get_items())[0]
+            self.assertEqual(test["expected_image"], stat[1].image)
+
+    def test_correct_image_in_whitelists(self):
+        rules = [{"name": "always True", "rule": lambda c: True}]
+
+        test_cases = [
+            {
+                "params": {"config": {"image": "busybox2", "labels": {}}, "image": "sha256:47bcffff", "name": "test1"},
+                "image_white_list": ["busybox2"],
+                "expected_verdict": False
+            },
+            {
+                "params": {"config": {"labels": {}}, "name": "test2"},
+                "image_white_list": ["UNDEFINED"],
+                "expected_verdict": False
+            },
+            {
+                "params": {"config": {"image": "busybox2", "labels": {}}, "image": "sha256:47bcffff", "name": "test1"},
+                "image_white_list": [],
+                "expected_verdict": True
+            },
+            {
+                "params": {"config": {"labels": {}}, "name": "test2"},
+                "image_white_list": [],
+                "expected_verdict": True
+            }
+
+        ]
+
+        for test in test_cases:
+            params = test["params"]
+
+            config = Config()
+            config.image_white_list = test["image_white_list"]
+
+            verdict_descr = RulesTestHelper(rules, container_params=params, config=config).get_verdicts()[0]
+            self.assertEquals(test["expected_verdict"], verdict_descr.verdict)
 
 
 class MetricsRulesTests(TestsWithVerdicts):


### PR DESCRIPTION
This PR fixes two issues:
1. Docker Enforcer does not show a correct initial image name. It shows the relate sha256 hash. It was because of this line [diff-635...](https://github.com/piontec/docker-enforcer/pull/53/files#diff-6356e2dbdc26cba800f391307eafe222L72) contained `Config` key value but has to have a `config` key value
2. Docker Enforcer fails with an exception when we send a request without information about an image. For example:
```
curl -H "Content-Type: application/json" -X POST -d '{}' "http://localhost:2375/v1.26/containers/create"
```
